### PR TITLE
fix: include codspeed iteration in --version output

### DIFF
--- a/bench/bench.py
+++ b/bench/bench.py
@@ -119,7 +119,7 @@ def pytest_generate_tests(metafunc):
 
         # If the valgrind version is from CodSpeed, we don't want to display the exact version
         # to allow comparison against older versions. 
-        if ".codspeed" in runner.valgrind_version:
+        if "codspeed" in runner.valgrind_version:
             runner.valgrind_version = "valgrind.codspeed"
 
         # Create test IDs with format: valgrind-version, command, config-name

--- a/configure.ac
+++ b/configure.ac
@@ -19,7 +19,11 @@ m4_define([v_major_ver], [3])
 m4_define([v_minor_ver], [26])
 m4_define([v_micro_ver], [0])
 m4_define([v_suffix_ver], [])
-m4_define([v_suffix_ver], [codspeed])
+m4_define([v_suffix_ver],
+	  m4_esyscmd_s([sed -n '1s/.*-[0-9]*\(codspeed[0-9]*\).*/\1/p' debian/changelog]))
+m4_if(m4_bregexp(v_suffix_ver, [^codspeed[0-9]+$]), [-1],
+      [m4_fatal([invalid codspeed suffix ']v_suffix_ver[' extracted from debian/changelog])])
+
 m4_define([v_rel_date], ["5 Nov 2025"])
 m4_define([v_version],
 	  m4_if(v_suffix_ver, [],


### PR DESCRIPTION
Derive v_suffix_ver in configure.ac from the top entry of debian/changelog so AC_INIT picks up the codspeedN iteration automatically, and join it with '-' to match the git-tag / deb-version format.

Before: valgrind-3.26.0.codspeed
After:  valgrind-3.26.0-codspeed2