### PR TITLE
ci: remove samply walltime profiler and pinned runner version

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -40,8 +40,14 @@ jobs:
         uses: actions/cache@v4
         id: valgrind-cache
         with:
-          path: /tmp/valgrind-build
-          key: valgrind-${{ matrix.valgrind }}-${{ runner.os }}-${{ matrix.valgrind == 'local' && hashFiles('coregrind/**', 'include/**', 'VEX/**', 'cachegrind/**', 'callgrind/**', 'dhat/**', 'drd/**', 'helgrind/**', 'lackey/**', 'massif/**', 'memcheck/**', 'none/**', 'exp-bbv/**', 'auxprogs/**', '*.ac', '*.am', '*.in', 'autogen.sh', 'configure*') || 'build' }}
+          # `.capstone` is the cycle-estimation decoder prefix; its absolute path
+          # is baked into the Makefile's -I flags, so `make install` (which may
+          # recompile cycledecode.o) needs it present. It is built outside
+          # /tmp/valgrind-build, so cache it too or a cache hit breaks install.
+          path: |
+            /tmp/valgrind-build
+            .capstone
+          key: valgrind-${{ matrix.valgrind }}-${{ runner.os }}-v2-${{ matrix.valgrind == 'local' && hashFiles('coregrind/**', 'include/**', 'VEX/**', 'cachegrind/**', 'callgrind/**', 'dhat/**', 'drd/**', 'helgrind/**', 'lackey/**', 'massif/**', 'memcheck/**', 'none/**', 'exp-bbv/**', 'auxprogs/**', '*.ac', '*.am', '*.in', 'autogen.sh', 'configure*') || 'build' }}
 
       # Build and install Valgrind
       - name: Update apt-get cache

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   benchmarks:
     runs-on: codspeed-macro
-    timeout-minutes: 30
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -103,4 +103,3 @@ jobs:
         with:
           mode: walltime
           config: bench/codspeed.yml
-          runner-version: 4.17.7-alpha.1

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -98,8 +98,6 @@ jobs:
 
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@main
-        env:
-          CODSPEED_WALLTIME_PROFILER: samply
         with:
           mode: walltime
           config: bench/codspeed.yml

--- a/bench/generate_config.py
+++ b/bench/generate_config.py
@@ -22,8 +22,6 @@ COMMANDS = [
     "testdata/take_strings-aarch64 varbinview_non_null",
     "echo Hello, World!",
     "python3 testdata/test.py",
-    "stress-ng --cpu 1 --cpu-ops 10",
-    "stress-ng --cpu 4 --cpu-ops 10",
 ]
 
 # Callgrind configurations: (extra args, config name, requires_codspeed). The


### PR DESCRIPTION
## Summary

- Reverts the WIP commit that pinned the runner to `4.17.7-alpha.1` to test samply
- Removes the `CODSPEED_WALLTIME_PROFILER: samply` env var from the benchmarks workflow step

The CI workflow returns to using `CodSpeedHQ/action@main` with the default runner version and default walltime profiler.

## Test plan

- [x] CI runs the benchmarks step successfully