### PR TITLE
fix(deb): drop 32-bit build-deps to match 64-bit-only build

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,8 +5,6 @@ Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
 XSBC-Original-Maintainer: Alessandro Ghedini <ghedo@debian.org>
 Build-Depends: debhelper-compat (= 12),
  gdb,
- gcc-multilib [amd64],
- libc6-dev-i386 [amd64],
  mpi-default-dev,
  pkgconf,
  docbook,


### PR DESCRIPTION
PR #17 stopped installing gcc-multilib/libc6-dev-i386 in the Release
workflow (the deb already forces --enable-only64bit) but left them in
debian/control Build-Depends, so dpkg-checkbuilddeps aborted debuild
before any compile and the release produced no .deb assets.
